### PR TITLE
Check instances of pieces at key locations to avoid execution errors

### DIFF
--- a/addons/ninetailsrabbit.match3_board/src/components/animators/piece_animator.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/animators/piece_animator.gd
@@ -106,7 +106,7 @@ func consume_pieces(pieces: Array[PieceUI]):
 	if pieces.size() > 0:
 		var tween: Tween = create_tween().set_parallel(true)
 		
-		for piece: PieceUI in pieces.filter(func(piece): return is_instance_valid(piece)):
+		for piece: PieceUI in pieces.filter(func(piece: PieceUI): return is_instance_valid(piece)):
 			tween.tween_property(piece, "scale", Vector2.ZERO, 0.15).set_ease(Tween.EASE_OUT)
 		
 		await tween.finished
@@ -117,16 +117,17 @@ func consume_pieces(pieces: Array[PieceUI]):
 func spawn_special_piece(target_cell: GridCellUI, new_piece: PieceUI):
 		animation_started.emit()
 		
-		new_piece.hide()
-		var tween: Tween = create_tween().set_parallel(true)
-		
-		tween.tween_property(target_cell.current_piece, "position", target_cell.position, 0.15)\
-			.set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
-		tween.chain()
-		tween.tween_property(new_piece, "visible", true, 0.1)
-		
-		await tween.finished
-		
+		if is_instance_valid(new_piece) and target_cell.current_piece == new_piece:
+			new_piece.hide()
+			var tween: Tween = create_tween().set_parallel(true)
+			
+			tween.tween_property(target_cell.current_piece, "position", target_cell.position, 0.15)\
+				.set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
+			tween.chain()
+			tween.tween_property(new_piece, "visible", true, 0.1)
+			
+			await tween.finished
+			
 		animation_finished.emit()
 
 

--- a/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
@@ -53,9 +53,10 @@ func consume_sequences(sequences: Array[Sequence]) -> void:
 
 
 func trigger_special_piece(sequence: Sequence, special_piece: PieceUI) -> void:
-	await special_piece.trigger_special_effect()
-	sequence.consume_piece(special_piece)
-	
+	if is_instance_valid(special_piece) and special_piece != null:
+		await special_piece.trigger_special_effect()
+		sequence.consume_piece(special_piece)
+		
 
 #region Overridables
 func detect_new_combined_piece(sequence: Sequence):

--- a/addons/ninetailsrabbit.match3_board/src/components/sequence.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/sequence.gd
@@ -100,7 +100,7 @@ func pieces() -> Array[PieceUI]:
 	current_pieces.assign(
 		Match3BoardPluginUtilities.remove_falsy_values(cells.map(func(grid_cell: GridCellUI): return grid_cell.current_piece)))
 	
-	return current_pieces.filter(func(piece): return is_instance_valid(piece))
+	return current_pieces.filter(func(piece: PieceUI): return is_instance_valid(piece) and piece != null)
 	
 	
 func normal_pieces_cells() -> Array[GridCellUI]:


### PR DESCRIPTION
## Description
The execution could be stopped when trying to access pieces that had already been consumed when there are large amounts of consumed pieces on the board.

## Addressed issues
#5 _**Added instance checks in a few places including the one in your video to prevent the workflow from stopping when there is a large consumption of parts.**_
