### PR TITLE
Overridable method custom_spawn_and_draw on PieceUI 

### DIFF
--- a/addons/ninetailsrabbit.match3_board/demo/pieces/special/special_cross_piece.gd
+++ b/addons/ninetailsrabbit.match3_board/demo/pieces/special/special_cross_piece.gd
@@ -9,7 +9,7 @@ var extra_sequence: Sequence
 func _ready() -> void:
 	super._ready()
 	animation_player.play("idle")
-
+	
 
 func trigger_special_effect() -> void:
 	if not triggered:

--- a/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
@@ -125,14 +125,20 @@ class ConsumeNormalSequenceAction extends SequenceAction:
 
 class DrawNewPieceSequenceAction extends SequenceAction:
 	func run() -> void:
-		var target_cell_to_spawn: GridCellUI = sequence.middle_cell()
-		
-		await consumer.board.piece_animator.consume_pieces(sequence.normal_pieces())
-		
-		sequence.consume_only_normal_pieces()
+		if arguments.has("new_piece") and is_instance_valid(arguments.new_piece):
+			arguments.new_piece.board = consumer.board
+			
+			var target_cell_to_spawn: GridCellUI = arguments.new_piece.custom_spawn_and_draw({"sequence": sequence})
+			
+			if target_cell_to_spawn == null:
+				target_cell_to_spawn = sequence.middle_cell()
+			
+			await consumer.board.piece_animator.consume_pieces(sequence.normal_pieces())
+			
+			sequence.consume_only_normal_pieces()
 
-		consumer.board.draw_piece_on_cell(target_cell_to_spawn, arguments.new_piece)
-		await consumer.board.piece_animator.spawn_special_piece(target_cell_to_spawn, arguments.new_piece)
+			consumer.board.draw_piece_on_cell(target_cell_to_spawn, arguments.new_piece)
+			await consumer.board.piece_animator.spawn_special_piece(target_cell_to_spawn, arguments.new_piece)
 		
 
 	func get_class_name() -> StringName:

--- a/addons/ninetailsrabbit.match3_board/src/components/pieces/piece_ui.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/pieces/piece_ui.gd
@@ -111,7 +111,7 @@ func _enter_tree() -> void:
 	if board == null:
 		board = get_tree().get_first_node_in_group(Match3Board.BoardGroupName)
 	
-	assert(board is Match3Board, "PieceUI: The piece ui needs a linked Match3Board to be functional. ")
+	assert(board is Match3Board, "PieceUI: The piece %s needs a linked Match3Board to be functional" % name)
 	
 	cell_size = board.cell_size
 	
@@ -419,6 +419,10 @@ func trigger_special_effect():
 	pass
 
 
+func custom_spawn_and_draw(arguments: Dictionary = {}):
+	return null
+	
+	
 func on_piece_selected() -> void:
 	pass
 	

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Match3_Board"
 config/description="This lightweight library provides the core logic and functionality you need to build engaging match-3 games. Focus on game design and mechanics while leaving the complex logic to this library"
-config/version="1.5.1"
+config/version="1.5.2"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
## Description
Right now the special pieces only spawned in the middle cell of the source sequence. This limits the possibility to add additional behaviour when these pieces want to be drawn on the board.

## Addressed issues

#7 - The special pieces now can define a custom logic to spawn in the board when sequence consumer detects them
