### PR TITLE
Fix special pieces not being consumed correctly (again)

### DIFF
--- a/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
+++ b/addons/ninetailsrabbit.match3_board/src/components/consumers/sequence_consumer.gd
@@ -114,7 +114,7 @@ class ConsumeNormalSequenceAction extends SequenceAction:
 		
 		await consumer.board.piece_animator.consume_pieces(sequence.normal_pieces())
 		
-		sequence.consume_only(sequence.normal_pieces_cells() + sequence.special_piece_cells(true))
+		sequence.consume_except(special_pieces_cells(false))
 	
 	func get_class_name() -> StringName:
 		return &"ConsumeNormalSequenceAction"


### PR DESCRIPTION
## Description

I am very sorry I didn't think it through clearly.
The correct behavior should be to consume all normal and special pieces except those that have not been triggered.
